### PR TITLE
Fix: 타겟 노드가 있으면 근처에 Toast 띄우기

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,4 +1,4 @@
-import { ButtonHTMLAttributes } from 'react';
+import React, { ButtonHTMLAttributes } from 'react';
 
 interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   size?: 'sm' | 'md';
@@ -6,14 +6,10 @@ interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: 'clear' | 'primary' | 'secondary';
 }
 
-const Button = ({
-  type,
-  children,
-  size = 'md',
-  weight = '',
-  variant = 'clear',
-  ...rest
-}: ButtonProps) => {
+const Button: React.ForwardRefRenderFunction<HTMLButtonElement, ButtonProps> = (
+  { type, children, size = 'md', weight = '', variant = 'clear', ...rest },
+  ref,
+) => {
   const SIZE = {
     sm: 'rounded-md px-2 py-1 text-xs',
     md: 'rounded-md px-3 py-[0.3125rem] text-sm',
@@ -35,6 +31,7 @@ const Button = ({
   return (
     <button
       type={type || 'button'}
+      ref={ref}
       className={`hover:cursor-pointer ${
         weight && `font-${weight}`
       } ${SIZE} ${BORDER} ${COLOR}`}
@@ -45,4 +42,4 @@ const Button = ({
   );
 };
 
-export default Button;
+export default React.forwardRef(Button);

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -1,0 +1,63 @@
+import Transition from 'src/components/Transition';
+import type { ToastPlacement } from 'types/toast';
+
+const Body = {
+  warn: 'bg-amber-300 text-slate-900',
+  error: 'bg-red-500 text-slate-50',
+};
+
+type ToastProps = {
+  variant: 'warn' | 'error';
+  target?: HTMLElement;
+  placement?: ToastPlacement; // target 기준 left, right
+  duration?: number;
+  className?: string;
+  close: () => void;
+};
+
+const Toast = ({
+  variant,
+  target,
+  placement,
+  duration = 1000,
+  className = '',
+  children,
+  close,
+}: React.PropsWithChildren<ToastProps>) => {
+  let x: number | string = 0;
+  let y: number = 5; // 적당한 여백
+
+  if (target !== undefined) {
+    switch (placement) {
+      case 'r':
+        x = `${target.offsetLeft + target.clientWidth / 2}px`;
+        break;
+      case 'l':
+        x = `calc(${target.offsetLeft + target.clientWidth / 2}px - 100%)`;
+        break;
+    }
+    y += target.offsetTop + target.clientHeight;
+  }
+
+  return (
+    <Transition
+      role="alert"
+      from={{ opacity: 0 }}
+      to={{ opacity: 1 }}
+      reverseDelay={duration}
+      onReverse={close}
+      style={{
+        transform: `translate3d(${x}, ${y}px, 0)`,
+      }}
+      className={`absolute top-0 ${x !== 0 && 'left-0'} ${
+        x === 0 && 'inset-x-0 text-center'
+      }`}
+    >
+      <div className={`${className} h-9 rounded-3xl px-5 ${Body[variant]}`}>
+        {children}
+      </div>
+    </Transition>
+  );
+};
+
+export default Toast;

--- a/src/components/Transition.tsx
+++ b/src/components/Transition.tsx
@@ -1,0 +1,66 @@
+import React, { useEffect, useState } from 'react';
+
+type TransitionProps = {
+  role?: string;
+  style?: React.CSSProperties;
+  className?: string;
+  from: React.CSSProperties;
+  to: React.CSSProperties;
+  delay?: number;
+  ease?: 'linear' | 'in' | 'out' | 'in-out';
+  duration?: number;
+  reverseDelay?: number;
+  onReverse?: () => void;
+};
+
+const TransitionDuration = 300;
+
+const Transition = ({
+  children,
+  role,
+  className = '',
+  from = { opacity: 0 },
+  to = { opacity: 1 },
+  delay = 0,
+  ease = 'in-out',
+  duration = TransitionDuration,
+  reverseDelay,
+  onReverse,
+  ...props
+}: React.PropsWithChildren<TransitionProps>) => {
+  const [isTransitionReady, setTransitionReady] = useState<boolean>(false);
+
+  const style: React.CSSProperties =
+    props.style !== undefined ? { ...props.style, ...from } : { ...from };
+  const properties = [];
+  for (const key in to) properties.push(key);
+  style.transitionProperty = properties.join(', ');
+
+  const reverse = () => {
+    if (reverseDelay !== undefined)
+      setTimeout(() => {
+        setTransitionReady(false);
+        if (onReverse !== undefined) setTimeout(onReverse, duration);
+      }, duration + reverseDelay);
+  };
+
+  useEffect(() => {
+    const delayTimeout = setTimeout(() => {
+      setTransitionReady(true);
+      if (reverseDelay !== undefined) reverse();
+    }, delay);
+    return () => clearTimeout(delayTimeout);
+  }, []);
+
+  return (
+    <div
+      role={role}
+      style={isTransitionReady ? { ...style, ...to } : style}
+      className={`${className} duration-${duration} ease-${ease}`}
+    >
+      {children}
+    </div>
+  );
+};
+
+export default Transition;

--- a/src/components/WritableComment.tsx
+++ b/src/components/WritableComment.tsx
@@ -40,6 +40,7 @@ const WritableComment: React.FC<WritableCommentProps> = ({ handleSubmit }) => {
 
   const [name, setName] = useState<string>('');
   const [content, setContent] = useState<string>('');
+  const submitButtonRef = useRef<HTMLButtonElement | null>(null);
   const isPrevInvalid = useRef<boolean>(false);
 
   useEffect(() => {
@@ -58,7 +59,7 @@ const WritableComment: React.FC<WritableCommentProps> = ({ handleSubmit }) => {
       e.preventDefault();
 
       if (!isPrevInvalid.current) {
-        errorToast(message);
+        errorToast(message, submitButtonRef.current as HTMLButtonElement, 'l');
         (e.target as HTMLInputElement | HTMLTextAreaElement).focus();
         isPrevInvalid.current = true;
       }
@@ -109,7 +110,7 @@ const WritableComment: React.FC<WritableCommentProps> = ({ handleSubmit }) => {
             }`}
             onClick={(e) => {
               e.preventDefault();
-              warnToast('준비 중, 곧 만나요!');
+              warnToast('준비 중, 곧 만나요!', e.target);
             }}
           >
             {avatar === undefined && '?'}
@@ -147,7 +148,12 @@ const WritableComment: React.FC<WritableCommentProps> = ({ handleSubmit }) => {
         onInvalid={handleInputInvalid('내용을 입력하세요.')}
       />
       <div className="mr-3 mt-1 text-right">
-        <Button type="submit" variant="primary" disabled={waitingCount > 0}>
+        <Button
+          type="submit"
+          ref={submitButtonRef}
+          variant="primary"
+          disabled={waitingCount > 0}
+        >
           {waitingCount > 0 && <Spinner />}
           {waitingCount === 0 && '등록'}
         </Button>

--- a/types/toast.d.ts
+++ b/types/toast.d.ts
@@ -1,0 +1,1 @@
+export type ToastPlacement = 'r' | 'l';


### PR DESCRIPTION
이벤트 핸들러 `target`을 받아서 근처에 안내 메시지를 띄운다.

<img src="https://github.com/jesh-hub/cocoment-sdk/assets/40452288/3519a125-6157-4d4d-b9e8-edbdb911013a" width="320" />
